### PR TITLE
Return -1 instead of NULL

### DIFF
--- a/unicodedataplus/unicodedata.c
+++ b/unicodedataplus/unicodedata.c
@@ -2226,11 +2226,11 @@ unicodedata_exec(PyObject *module)
 
     PyObject *propval_aliases = unicodedata_build_propval_aliases();
     if (!propval_aliases)
-        return NULL;
+        return -1;
     PyModule_AddObject(module, "property_value_aliases", propval_aliases);
     PyObject *propval_by_alias = unicodedata_build_propval_by_alias();
     if (!propval_by_alias)
-        return NULL;
+        return -1;
     PyModule_AddObject(module, "property_value_by_alias", propval_by_alias);
 
     // Unicode database version 3.2.0 used by the IDNA encoding


### PR DESCRIPTION
When trying to pip install with Python 3.12 on macOS Silicon I'm getting 

```
./unicodedataplus/unicodedata.c:2229:16: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
              return NULL;
                     ^~~~
      /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      ./unicodedataplus/unicodedata.c:2233:16: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
              return NULL;
                     ^~~~
      /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/15.0.0/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      2 errors generated.
      error: command '/usr/bin/clang' failed with exit code 1
```

Returning -1 on these lets it pass and everything seems to work, but I admit I haven't looked in much detail and haven't tested thoroughly. 
