### PR TITLE
Build Linux ARM64 wheels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       CIBW_ARCHS: ${{ matrix.arch }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         arch: [auto]
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
         env:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {project}/tests
-          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* pp37-* pp38-*
+          CIBW_SKIP: cp36-* cp37-* cp38-* cp39-* pp37-* pp38-* pp39-*
       - uses: actions/upload-artifact@v4
         with:
           name: unicodedataplus-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
Build Linux aarch64 wheels on a native ARM64 GitHub Actions runner.

Also skip PyPy 3.9 wheel builds to match b88126dc9e, which removed Python 3.9 support. The unsupported PyPy 3.9 macOS build currently fails and cancels the other wheel builds.